### PR TITLE
Improve festival JsonLd

### DIFF
--- a/app/[locale]/(with-map)/festival/[slug]/getFestivalJsonLd.ts
+++ b/app/[locale]/(with-map)/festival/[slug]/getFestivalJsonLd.ts
@@ -24,9 +24,7 @@ function getOffsetForTimeZone(date: Date): string {
 function getDateTime(date: string, time: string): string {
   const dateTime = new Date(`${date}T${getTime(time)}`);
   const offset = getOffsetForTimeZone(dateTime);
-  const result = `${date}T${getTime(time)}+${offset}`;
-  console.log("date time: ", result);
-  return result;
+  return `${date}T${getTime(time)}+${offset}`;
 }
 
 export default function getFestivalJsonLd(

--- a/app/[locale]/(with-map)/festival/[slug]/getFestivalJsonLd.ts
+++ b/app/[locale]/(with-map)/festival/[slug]/getFestivalJsonLd.ts
@@ -1,5 +1,33 @@
+import { TIME_ZONE } from "@/app/constants";
 import { Festival } from "@/app/types";
 import { Event, WithContext } from "schema-dts";
+
+function getTime(partialTime: string): string {
+  return `${partialTime}:00`;
+}
+
+function getOffsetForTimeZone(date: Date): string {
+  // Since the timezone offset depends on daylight saving time we need to retrieve it dynamically
+  // Uses workaround with Intl.DateTimeFormat
+  // TODO Use Temporal when available
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: TIME_ZONE,
+    timeZoneName: "short",
+  });
+  const parts = formatter.formatToParts(date);
+  const tzNamePart = parts.find((part) => part.type === "timeZoneName");
+  if (!tzNamePart) return "";
+  const offsetHours = tzNamePart.value.slice(-1);
+  return `${offsetHours}:00`;
+}
+
+function getDateTime(date: string, time: string): string {
+  const dateTime = new Date(`${date}T${getTime(time)}`);
+  const offset = getOffsetForTimeZone(dateTime);
+  const result = `${date}T${getTime(time)}+${offset}`;
+  console.log("date time: ", result);
+  return result;
+}
 
 export default function getFestivalJsonLd(
   festival: Festival,
@@ -14,12 +42,15 @@ export default function getFestivalJsonLd(
       "@type": "Schedule",
       startDate: festival.dates[0],
       endDate: festival.dates[festival.dates.length - 1],
-      startTime: `${festival.startTime}:00`,
-      endTime: `${festival.endTime}:00`,
+      startTime: getTime(festival.startTime),
+      endTime: getTime(festival.endTime),
       scheduleTimezone: "Europe/Amsterdam",
     },
-    startDate: `${festival.dates[0]}T${festival.startTime}:00`,
-    endDate: `${festival.dates[festival.dates.length - 1]}T${festival.endTime}:00`,
+    startDate: getDateTime(festival.dates[0], festival.startTime),
+    endDate: getDateTime(
+      festival.dates[festival.dates.length - 1],
+      festival.endTime,
+    ),
     location: {
       "@type": "Place",
       name: festival.location,

--- a/app/[locale]/(with-map)/festival/[slug]/getFestivalJsonLd.ts
+++ b/app/[locale]/(with-map)/festival/[slug]/getFestivalJsonLd.ts
@@ -18,6 +18,8 @@ export default function getFestivalJsonLd(
       endTime: `${festival.endTime}:00`,
       scheduleTimezone: "Europe/Amsterdam",
     },
+    startDate: `${festival.dates[0]}T${festival.startTime}:00`,
+    endDate: `${festival.dates[festival.dates.length - 1]}T${festival.endTime}:00`,
     location: {
       "@type": "Place",
       name: festival.location,

--- a/app/actions/getEvents.ts
+++ b/app/actions/getEvents.ts
@@ -8,8 +8,8 @@ import isClosed from "@/app/utils/isClosed";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
+import { TIME_ZONE } from "../constants";
 
-const TIME_ZONE = "Europe/Amsterdam";
 // const LOCALE = "NL-nl";
 
 dayjs.extend(utc);

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -1,1 +1,2 @@
 export const BASE_URL = "https://repaircafe.amsterdam/";
+export const TIME_ZONE = "Europe/Amsterdam";


### PR DESCRIPTION
To make the festival pages eligible for Google Search's rich results it needed a startData in it's JSON-LD data. 
> Invalid items are not eligible for Google Search's rich results. [Learn more](https://support.google.com/webmasters/answer/9012289#enhancements)
> Missing field "startDate"

https://search.google.com/test/rich-results/result/r%2Fevents?id=9WkpiV_pawIhJJE5ZbCDeQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced festival event data by adding clear start and end date-time details in a standardized format, providing more precise scheduling information.
  - Introduced a new constant for managing time zone configurations, improving maintainability across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->