### PR TITLE
Include festivals until their end time

### DIFF
--- a/app/actions/getEvents.ts
+++ b/app/actions/getEvents.ts
@@ -157,7 +157,8 @@ export default async function getEvents({
         endTime,
       } = festival;
       for (const rawDate of rawDates) {
-        const date = dayjs.tz(`${rawDate}T${startTime}`);
+        // using end time so we include already started festivals
+        const date = dayjs.tz(`${rawDate}T${endTime}`);
         if (date.isAfter(startDate) && date.isBefore(endDate)) {
           events.push(
             createEvent({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event filtering to ensure ongoing festivals are correctly included when they have already started but not yet ended within the selected date range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->