### PR TITLE
Use festival start time (and date) for sorting

### DIFF
--- a/app/actions/getEvents.ts
+++ b/app/actions/getEvents.ts
@@ -157,16 +157,20 @@ export default async function getEvents({
         endTime,
       } = festival;
       for (const rawDate of rawDates) {
+        const festivalStartDate = dayjs.tz(`${rawDate}T${startTime}`);
         // using end time so we include already started festivals
-        const date = dayjs.tz(`${rawDate}T${endTime}`);
-        if (date.isAfter(startDate) && date.isBefore(endDate)) {
+        const festivalEndDate = dayjs.tz(`${rawDate}T${endTime}`);
+        if (
+          festivalEndDate.isAfter(startDate) &&
+          festivalEndDate.isBefore(endDate)
+        ) {
           events.push(
             createEvent({
               name,
               slug,
               district,
               festival: true,
-              date: date.toDate(),
+              date: festivalStartDate.toDate(),
               startTime,
               endTime,
               locale,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of festival event dates by displaying the festival's start date instead of the end date, while maintaining correct filtering for events within the requested date range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->