### PR TITLE
Add smooth scroll when event is selected

### DIFF
--- a/app/[locale]/(with-map)/Upcoming.tsx
+++ b/app/[locale]/(with-map)/Upcoming.tsx
@@ -20,7 +20,7 @@ export default function Upcoming({ events }: { events: Event[] }) {
           </h2>
           <ul className="mb-3 flex flex-col last:mb-0">
             {group.events.map((event) => (
-              <li key={event.slug}>
+              <li key={event.slug} id={event.slug}>
                 <UpcomingItem event={event} />
               </li>
             ))}

--- a/app/[locale]/(with-map)/UpcomingItem.tsx
+++ b/app/[locale]/(with-map)/UpcomingItem.tsx
@@ -8,6 +8,7 @@ import classes from "@/app/utils/classes";
 import useLinkPostfix from "@/app/utils/useLinkPostfix";
 import { useTranslations } from "next-intl";
 import { useParams } from "next/navigation";
+import { useEffect } from "react";
 
 export default function UpcomingItem({ event }: { event: Event }) {
   const { slug, name, startTime, endTime, district, verified, festival } =
@@ -20,6 +21,18 @@ export default function UpcomingItem({ event }: { event: Event }) {
   const t = useTranslations("agenda");
   const rootT = useTranslations();
   const linkBase = festival ? "/festival" : "/cafe";
+
+  useEffect(() => {
+    if (isOpen) {
+      const selectedItem = document.getElementById(slug);
+      selectedItem?.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+        inline: "center",
+      });
+    }
+  }, [isOpen, slug]);
+
   return (
     <Link
       href={`${linkBase}/${slug}${linkPostfix}`}


### PR DESCRIPTION
As a user, I find a quick UX improvement by scrolling to the selected pin on the map. 

When a pin is not loaded in the Upcoming Items list, scrolling does not occur. I do not consider this a problem, as it reflects the current behavior.

https://github.com/user-attachments/assets/6c74a8fb-5f0a-48f6-9815-05e346871540



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Event items in the upcoming events list now automatically scroll into view when selected, enhancing navigation and visibility.

* **Accessibility**
  * Each event item in the list now includes an ID attribute, improving accessibility and direct linking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->