### PR TITLE
Stats

### DIFF
--- a/app/[locale]/stats/page.tsx
+++ b/app/[locale]/stats/page.tsx
@@ -1,0 +1,97 @@
+import data from "@/data/data/cafes.json";
+import BasePage from "@/app/components/BasePage";
+import { Metadata } from "next";
+import { BASE_URL } from "@/app/constants";
+import { EventRC } from "@/app/types";
+import { Suspense } from "react";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import { useTranslations } from "next-intl";
+import getEvents from "@/app/actions/getEvents";
+
+export async function generateMetadata(props: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+
+  const { locale } = params;
+
+  const t = await getTranslations({
+    locale,
+    namespace: "stats.metadata",
+  });
+
+  return {
+    title: t("title"),
+    alternates: {
+      canonical: BASE_URL + "stats",
+    },
+  };
+}
+
+type Stats = {
+  numRepairCafes: number;
+  periodMonths: number;
+  periodDays: number;
+  numEvents: number;
+};
+
+export default async function Page(props: {
+  params: Promise<{ locale: string }>;
+}) {
+  const params = await props.params;
+
+  const { locale } = params;
+  setRequestLocale(locale);
+  const t = await getTranslations({ locale, namespace: "stats" });
+
+  const periodMonths = 12;
+  const periodDays = 365;
+  const events: EventRC[] = await getEvents({
+    numMonths: periodMonths,
+    locale,
+  });
+  const stats: Stats = {
+    numRepairCafes: data.length,
+    periodMonths,
+    periodDays,
+    numEvents: events.length,
+  };
+  return (
+    <BasePage title={t("title")}>
+      <Suspense>
+        <ClientPage stats={stats} params={props.params} />
+      </Suspense>
+    </BasePage>
+  );
+}
+
+async function ClientPage(props: {
+  stats: Stats;
+  params: Promise<{ locale: string }>;
+}) {
+  const { numRepairCafes, periodMonths, periodDays, numEvents } = props.stats;
+  const t = useTranslations("stats");
+  return (
+    <div className="prose px-3 pb-3">
+      <ul>
+        <li>{t("rcs", { numRepairCafes })}</li>
+        <li>
+          {t("period", { periodMonths })}
+          <ul>
+            <li>{t("events", { numEvents })}</li>
+            <li>
+              {t("eventsPerMonth", {
+                numEventsPerMonth: (numEvents / periodMonths).toFixed(2),
+              })}
+            </li>
+            <li>
+              {t("eventsPerDay", {
+                numEventsPerDay: (numEvents / periodDays).toFixed(2),
+              })}
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/app/[locale]/stats/page.tsx
+++ b/app/[locale]/stats/page.tsx
@@ -2,11 +2,12 @@ import data from "@/data/data/cafes.json";
 import BasePage from "@/app/components/BasePage";
 import { Metadata } from "next";
 import { BASE_URL } from "@/app/constants";
-import { EventRC } from "@/app/types";
+import { Event } from "@/app/types";
 import { Suspense } from "react";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { useTranslations } from "next-intl";
 import getEvents from "@/app/actions/getEvents";
+import groupBy from "lodash/groupBy";
 
 export async function generateMetadata(props: {
   params: Promise<{ locale: string }>;
@@ -33,6 +34,7 @@ type Stats = {
   periodMonths: number;
   periodDays: number;
   numEvents: number;
+  numDaysWithEvents: number;
 };
 
 export default async function Page(props: {
@@ -46,30 +48,37 @@ export default async function Page(props: {
 
   const periodMonths = 12;
   const periodDays = 365;
-  const events: EventRC[] = await getEvents({
+  const events: Event[] = await getEvents({
     numMonths: periodMonths,
     locale,
   });
+  const eventsByDate = groupBy(events, (event: Event) => event.dateString);
+  const numDaysWithEvents = Object.keys(eventsByDate).length;
   const stats: Stats = {
     numRepairCafes: data.length,
     periodMonths,
     periodDays,
     numEvents: events.length,
+    numDaysWithEvents,
   };
   return (
     <BasePage title={t("title")}>
       <Suspense>
-        <ClientPage stats={stats} params={props.params} />
+        <ClientPage stats={stats} locale={locale} />
       </Suspense>
     </BasePage>
   );
 }
 
-async function ClientPage(props: {
-  stats: Stats;
-  params: Promise<{ locale: string }>;
-}) {
-  const { numRepairCafes, periodMonths, periodDays, numEvents } = props.stats;
+async function ClientPage(props: { stats: Stats; locale: string }) {
+  const {
+    numRepairCafes,
+    periodMonths,
+    periodDays,
+    numEvents,
+    numDaysWithEvents,
+  } = props.stats;
+  const { locale } = props;
   const t = useTranslations("stats");
   return (
     <div className="prose px-3 pb-3">
@@ -87,6 +96,20 @@ async function ClientPage(props: {
             <li>
               {t("eventsPerDay", {
                 numEventsPerDay: (numEvents / periodDays).toFixed(2),
+              })}
+            </li>
+            <li>{t("daysWithEvents", { numDaysWithEvents })}</li>
+            <li>
+              {t("dailyCoverage", {
+                dailyCoverage: (numDaysWithEvents / periodDays).toLocaleString(
+                  locale,
+                  { style: "percent", minimumFractionDigits: 2 },
+                ),
+              })}
+            </li>
+            <li>
+              {t("daysWithoutEvents", {
+                numDaysWithoutEvents: periodDays - numDaysWithEvents,
               })}
             </li>
           </ul>

--- a/app/[locale]/stats/page.tsx
+++ b/app/[locale]/stats/page.tsx
@@ -79,7 +79,7 @@ async function ClientPage(props: { stats: Stats; locale: string }) {
     numDaysWithEvents,
   } = props.stats;
   const { locale } = props;
-  const t = useTranslations("stats");
+  const t = await getTranslations({ locale, namespace: "stats" });
   return (
     <div className="prose px-3 pb-3">
       <ul>

--- a/messages/en.json
+++ b/messages/en.json
@@ -137,8 +137,11 @@
     },
     "rcs": "{numRepairCafes} Repair Cafés",
     "period": "In the last {periodMonths} months:",
-    "events": "{numEvents} events",
-    "eventsPerMonth": "±{numEventsPerMonth} events per month",
-    "eventsPerDay": "±{numEventsPerDay} events per day"
+    "events": "{numEvents} Repair Cafés were organized",
+    "eventsPerMonth": "±{numEventsPerMonth} per month",
+    "eventsPerDay": "±{numEventsPerDay} per day",
+    "daysWithEvents": "{numDaysWithEvents} days with Repair Cafés",
+    "dailyCoverage": "±{dailyCoverage} of days with at least one Repair Café",
+    "daysWithoutEvents": "{numDaysWithoutEvents} days without any Repair Café"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -129,5 +129,16 @@
     "metadata": {
       "title": "{name} events - Repair Cafes in Amsterdam"
     }
+  },
+  "stats": {
+    "title": "Statistics",
+    "metadata": {
+      "title": "Statistics - Repair Cafes in Amsterdam"
+    },
+    "rcs": "{numRepairCafes} Repair Cafés",
+    "period": "In the last {periodMonths} months:",
+    "events": "{numEvents} events",
+    "eventsPerMonth": "±{numEventsPerMonth} events per month",
+    "eventsPerDay": "±{numEventsPerDay} events per day"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -135,13 +135,13 @@
     "metadata": {
       "title": "Statistics - Repair Cafes in Amsterdam"
     },
-    "rcs": "{numRepairCafes} Repair Cafés",
-    "period": "In the last {periodMonths} months:",
-    "events": "{numEvents} Repair Cafés were organized",
+    "rcs": "{numRepairCafes} Repair {numRepairCafes, plural, one {Café} other {Cafés}}",
+    "period": "During the next {periodMonths} {periodMonths, plural, one {month} other {months}}:",
+    "events": "{numEvents} Repair {numEvents, plural, one {Café is} other {Cafés are}} organized",
     "eventsPerMonth": "±{numEventsPerMonth} per month",
     "eventsPerDay": "±{numEventsPerDay} per day",
-    "daysWithEvents": "{numDaysWithEvents} days with Repair Cafés",
-    "dailyCoverage": "±{dailyCoverage} of days with at least one Repair Café",
-    "daysWithoutEvents": "{numDaysWithoutEvents} days without any Repair Café"
+    "daysWithEvents": "{numDaysWithEvents} {numDaysWithEvents, plural, one {day} other {days}} with at least one Repair Café",
+    "dailyCoverage": "{dailyCoverage} days have at least one Repair Café",
+    "daysWithoutEvents": "{numDaysWithoutEvents} {numDaysWithoutEvents, plural, one {day} other {days}} without any Repair Café"
   }
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -129,5 +129,19 @@
     "metadata": {
       "title": "{name} evenementen - Repair Cafes in Amsterdam"
     }
+  },
+  "stats": {
+    "title": "Statistieken",
+    "metadata": {
+      "title": "Statistieken - Repair Cafes in Amsterdam"
+    },
+    "rcs": "{numRepairCafes} Repair Cafés",
+    "period": "In de laatste {periodMonths} maanden:",
+    "events": "{numEvents} Repair Cafés werden georganiseerd",
+    "eventsPerMonth": "±{numEventsPerMonth} per maand",
+    "eventsPerDay": "±{numEventsPerDay} per dag",
+    "daysWithEvents": "{numDaysWithEvents} dagen met Repair Cafés",
+    "dailyCoverage": "±{dailyCoverage} van de dagen met minstens één Repair Café",
+    "daysWithoutEvents": "{numDaysWithoutEvents} dagen zonder Repair Café"
   }
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -135,13 +135,13 @@
     "metadata": {
       "title": "Statistieken - Repair Cafes in Amsterdam"
     },
-    "rcs": "{numRepairCafes} Repair Cafés",
-    "period": "In de laatste {periodMonths} maanden:",
-    "events": "{numEvents} Repair Cafés werden georganiseerd",
+    "rcs": "{numRepairCafes} Repair {numRepairCafes, plural, one {Café} other {Cafés}}",
+    "period": "Tijdens de komende {periodMonths} {periodMonths, plural, one {maand} other {maanden}}:",
+    "events": "{numEvents} Repair {numEvents, plural, one {Café wordt} other {Cafés worden}} georganiseerd",
     "eventsPerMonth": "±{numEventsPerMonth} per maand",
     "eventsPerDay": "±{numEventsPerDay} per dag",
-    "daysWithEvents": "{numDaysWithEvents} dagen met Repair Cafés",
-    "dailyCoverage": "±{dailyCoverage} van de dagen met minstens één Repair Café",
-    "daysWithoutEvents": "{numDaysWithoutEvents} dagen zonder Repair Café"
+    "daysWithEvents": "{numDaysWithEvents} {numDaysWithEvents, plural, one {dag} other {dagen}} met minstens één Repair Café",
+    "dailyCoverage": "{dailyCoverage} van de dagen hebben minstens één Repair Café",
+    "daysWithoutEvents": "{numDaysWithoutEvents} {numDaysWithoutEvents, plural, one {dag} other {dagen}} zonder Repair Café"
   }
 }


### PR DESCRIPTION
Building up towards https://github.com/Repaircafes-in-Amsterdam/Repaircafes-in-Amsterdam/issues/32 with some text only stats that I couldn't calculate in the spreadsheet. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a localized Statistics page (EN & NL) showing repair café counts, total events, monthly/daily averages, days with/without events, and daily coverage percentage; uses a fixed 12-month reporting window and localized page metadata.
* **Documentation**
  * Added translation strings for all statistics UI text and metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->